### PR TITLE
Added IOCTL_CCID_ESCAPE to TS exports

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -46,6 +46,7 @@ interface CardReader extends EventEmitter {
   SCARD_RESET_CARD: number;
   SCARD_UNPOWER_CARD: number;
   SCARD_EJECT_CARD: number;
+  IOCTL_CCID_ESCAPE: number;
   name: string;
   state: number;
   connected: boolean;


### PR DESCRIPTION
Added platform specific constant IOCTL_CCID_ESCAPE as an export in the Typescript type definition file.